### PR TITLE
Always install systemd unit files in right place

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 install(PROGRAMS cgproxyd TYPE BIN)
 install(PROGRAMS cgnoproxy TYPE BIN)
 install(PROGRAMS cgroup-tproxy.sh DESTINATION ${CMAKE_INSTALL_DATADIR}/cgproxy/scripts)
-install(FILES cgproxy.service DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/system)
+install(FILES cgproxy.service DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system)
 install(FILES config.json DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/cgproxy)
 install(FILES readme.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
 


### PR DESCRIPTION
Systemd unit files should always be installed into `/usr/lib`, see [Systemd.unit][ref]. (In some cases, for x64 platform, libraries should be installed in `/usr/lib64`, `CMAKE_INSTALL_LIBDIR` will be `/usr/lib64` in this case).

[ref]: https://www.freedesktop.org/software/systemd/man/systemd.unit.html﻿
