### PR TITLE
Don't hardcode paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,11 +27,15 @@ if (build_test)
     add_subdirectory(test)
 endif()
 
+configure_file(cgnoproxy.cmake cgnoproxy)
+configure_file(cgproxyd.cmake cgproxyd)
+configure_file(cgproxy.service.cmake cgproxy.service)
+
 # instal scripts and other things
-install(PROGRAMS cgproxyd TYPE BIN)
-install(PROGRAMS cgnoproxy TYPE BIN)
+install(PROGRAMS ${CMAKE_BINARY_DIR}/cgproxyd TYPE BIN)
+install(PROGRAMS ${CMAKE_BINARY_DIR}/cgnoproxy TYPE BIN)
 install(PROGRAMS cgroup-tproxy.sh DESTINATION ${CMAKE_INSTALL_DATADIR}/cgproxy/scripts)
-install(FILES cgproxy.service DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system)
+install(FILES ${CMAKE_BINARY_DIR}/cgproxy.service DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system)
 install(FILES config.json DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/cgproxy)
 install(FILES readme.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
 

--- a/cgnoproxy
+++ b/cgnoproxy
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec /usr/bin/cgproxy --noproxy $@

--- a/cgnoproxy.cmake
+++ b/cgnoproxy.cmake
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec @CMAKE_INSTALL_FULL_BINDIR@/cgproxy --noproxy $@

--- a/cgproxy.service.cmake
+++ b/cgproxy.service.cmake
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/cgproxyd --execsnoop
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/cgproxyd --execsnoop
 
 [Install]
 WantedBy=multi-user.target

--- a/cgproxyd
+++ b/cgproxyd
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec /usr/bin/cgproxy --daemon $@

--- a/cgproxyd.cmake
+++ b/cgproxyd.cmake
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec @CMAKE_INSTALL_FULL_BINDIR@/cgproxy --daemon $@

--- a/execsnoop-bcc/CMakeLists.txt
+++ b/execsnoop-bcc/CMakeLists.txt
@@ -3,4 +3,4 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(execsnoop MODULE execsnoop.cpp ../src/common.cpp)
 target_link_libraries(execsnoop bcc)
-install(TARGETS execsnoop DESTINATION /usr/lib/cgproxy/ PERMISSIONS ${basic_permission})
+install(TARGETS execsnoop DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cgproxy/ PERMISSIONS ${basic_permission})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,9 @@ find_package(nlohmann_json REQUIRED)
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_SOURCE_DIR}/execsnoop-kernel/)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
+configure_file(common.h.cmake common.h)
 
 if (build_execsnoop_dl)
     add_definitions(-DBUIlD_EXECSNOOP_DL)

--- a/src/common.h.cmake
+++ b/src/common.h.cmake
@@ -7,15 +7,15 @@
 #include <vector>
 using namespace std;
 
-#define TPROXY_IPTABLS_START "/usr/share/cgproxy/scripts/cgroup-tproxy.sh"
-#define TPROXY_IPTABLS_CLEAN "/usr/share/cgproxy/scripts/cgroup-tproxy.sh stop"
+#define TPROXY_IPTABLS_START "@CMAKE_INSTALL_FULL_DATADIR@/cgproxy/scripts/cgroup-tproxy.sh"
+#define TPROXY_IPTABLS_CLEAN "@CMAKE_INSTALL_FULL_DATADIR@/cgproxy/scripts/cgroup-tproxy.sh stop"
 
-#define LIBEXECSNOOP_SO "/usr/lib/cgproxy/libexecsnoop.so"
+#define LIBEXECSNOOP_SO "@CMAKE_INSTALL_FULL_LIBDIR@/cgproxy/libexecsnoop.so"
 #define CGROUP2_MOUNT_POINT "/var/run/cgproxy/cgroup2"
 #define PID_LOCK_FILE "/var/run/cgproxyd.pid"
 #define SOCKET_PATH "/tmp/cgproxy_unix_socket"
 #define LISTEN_BACKLOG 64
-#define DEFAULT_CONFIG_FILE "/etc/cgproxy/config.json"
+#define DEFAULT_CONFIG_FILE "@CMAKE_INSTALL_FULL_SYSCONFDIR@/cgproxy/config.json"
 #define READ_SIZE_MAX 128
 
 #define CGROUP_PROXY_PRESVERED "/proxy.slice"

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,4 +2,4 @@ include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
 add_executable(cgattach cgattach.cpp ../src/cgroup_attach.cpp ../src/common.cpp)
-install(TARGETS cgattach  DESTINATION /usr/bin PERMISSIONS ${basic_permission})
+install(TARGETS cgattach  DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} PERMISSIONS ${basic_permission})


### PR DESCRIPTION
Hardcoding paths will lead problems when the user decide to install the whole program into somewhere else (e.g. `/usr/local`). And the hard-coded path of `/usr/lib/cgproxy/libexecsnoop.so` will certainly lead to problems when `-DLIB_INSTALL_DIR:PATH=/usr/lib64` is set.

With this patch, I can package this in [fedora copr][1] along with fedora packaging guideline. 

After merged and new release tagged, I can try to package this to fedora package collection.

[1]: https://copr.fedorainfracloud.org/coprs/yanqiyu/cgproxy/