### PR TITLE
Add network-online.target

### DIFF
--- a/cgproxy.service
+++ b/cgproxy.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=cgproxy service
-After=network.target
+After=network.target network-online.target
 
 [Service]
 Type=simple

--- a/cgproxy.service.cmake
+++ b/cgproxy.service.cmake
@@ -1,6 +1,6 @@
 [Unit]
 Description=cgproxy service
-After=network.target
+After=network.target network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
If Firewalld is enabled, Cgproxy should running after the network was up to online to avoid conflict from Firewalld.
karuboniru found the cause, and I found the solution from zfl9/ss-tproxy. Thanks to zfl9 and karuboniru.