### PR TITLE
test, tools: find header files in build dir

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_SOURCE_DIR}/src)
+include_directories(${PROJECT_BINARY_DIR}/src)
 
 find_package(nlohmann_json REQUIRED)
 add_executable(client_test socket_client_test.cpp

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_SOURCE_DIR}/src)
+include_directories(${PROJECT_BINARY_DIR}/src)
 
 add_executable(cgattach cgattach.cpp ../src/cgroup_attach.cpp ../src/common.cpp)
 install(TARGETS cgattach  DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} PERMISSIONS ${basic_permission})


### PR DESCRIPTION
`common.h` be changed in 655290bf97f2dc71b3b1cf107d15178996cf620f, if we build out of source, that can not be found in `/src` anymore.
but it can be found in `build/src` after cmake.
So I add a `include_directories(${PROJECT_BINARY_DIR}/src)` both in `test/CMakeLists.txt` and `tools/CMakeLists.txt`, to avoid `build_test=ON` , `build_tools=ON` build error because `common.h` not found.