### PR TITLE
service: restart when cgproxy exits non-manually

### DIFF
--- a/cgproxy.service.cmake
+++ b/cgproxy.service.cmake
@@ -5,6 +5,7 @@ After=network.target network-online.target
 [Service]
 Type=simple
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/cgproxyd --execsnoop
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Calling `cgproxy` / `cgnoproxy` multiple times in a while may cause `cgproxy.service` exits silently, so i suggest to add this into systemd config.