### PR TITLE
Fix compilation errors on arm64

### DIFF
--- a/execsnoop-kernel/execsnoop_share.cpp
+++ b/execsnoop-kernel/execsnoop_share.cpp
@@ -7,7 +7,7 @@
 
 #if defined(__x86_64__)
 	#include "x86_64/execsnoop_kern_skel.h"
-#elif defined(__aarch64__)
+#else
 	#include "aarch64/execsnoop_kern_skel.h"
 #endif
 


### PR DESCRIPTION
This pull request fixes compilation errors on arm64 machines like Raspberry Pi, the third compilation error mentioned in [this comment](https://github.com/springzfx/cgproxy/issues/22#issuecomment-812908753) from #22 should have been fixed now.

This code compiles successfully on my Raspberry Pi 4B and works with no issue so far.

Signed-off-by: Gaoyang Zhang <gy@blurgy.xyz>